### PR TITLE
Fix config center

### DIFF
--- a/compatibility/config-api/configcenter/nacos/go-client/cmd/client.go
+++ b/compatibility/config-api/configcenter/nacos/go-client/cmd/client.go
@@ -32,7 +32,7 @@ import (
 	"github.com/apache/dubbo-go-samples/compatibility/api"
 )
 
-const configCenterNacosClientConfig = `## set in config center, group is 'dubbo', dataid is 'dubbo-go-samples-configcenter-nacos-client', namespace is default
+const configCenterNacosClientConfig = `
 dubbo:
   registries:
     demoZK:

--- a/compatibility/config-api/configcenter/nacos/go-server/cmd/server.go
+++ b/compatibility/config-api/configcenter/nacos/go-server/cmd/server.go
@@ -33,7 +33,7 @@ import (
 	"github.com/apache/dubbo-go-samples/compatibility/api"
 )
 
-const configCenterNacosServerConfig = `# set in config center, group is 'dubbo', dataid is 'dubbo-go-samples-configcenter-nacos-server', namespace is default
+const configCenterNacosServerConfig = `
 dubbo:
   registries:
     demoZK:

--- a/config_center/zookeeper/go-client/cmd/main.go
+++ b/config_center/zookeeper/go-client/cmd/main.go
@@ -40,71 +40,112 @@ import (
 )
 
 func main() {
-	_ = writeRuleToConfigCenter()
+	// write configuration to config center
+	if err := writeRuleToConfigCenter(); err != nil {
+		logger.Errorf("Failed to write config to config center: %v", err)
+		panic(err)
+	}
+	logger.Info("Successfully wrote config to ZooKeeper")
 
-	time.Sleep(time.Second * 10)
+	// wait for config write to finish
+	time.Sleep(time.Second * 3)
 
+	// configure Dubbo instance
 	zkOption := config_center.WithZookeeper()
 	dataIdOption := config_center.WithDataID("dubbo-go-samples-configcenter-zookeeper-client")
 	addressOption := config_center.WithAddress("127.0.0.1:2181")
 	groupOption := config_center.WithGroup("dubbogo")
+
 	ins, err := dubbo.NewInstance(
 		dubbo.WithConfigCenter(zkOption, dataIdOption, addressOption, groupOption),
 	)
 	if err != nil {
+		logger.Errorf("Failed to create Dubbo instance: %v", err)
 		panic(err)
 	}
-	// configure the params that only client layer cares
+
+	// create client
 	cli, err := ins.NewClient()
 	if err != nil {
+		logger.Errorf("Failed to create Dubbo client: %v", err)
 		panic(err)
 	}
 
+	// create service proxy
 	svc, err := greet.NewGreetService(cli)
 	if err != nil {
+		logger.Errorf("Failed to create GreetService: %v", err)
 		panic(err)
 	}
 
-	resp, err := svc.Greet(context.Background(), &greet.GreetRequest{Name: "hello world"})
+	// call remote service
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	resp, err := svc.Greet(ctx, &greet.GreetRequest{Name: "hello world"})
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("Failed to call Greet service: %v", err)
+		return
 	}
 	logger.Infof("Greet response: %s", resp)
 }
 
 func writeRuleToConfigCenter() error {
+	// connect to ZooKeeper
 	c, _, err := zk.Connect([]string{"127.0.0.1:2181"}, time.Second*10)
 	if err != nil {
-		panic(err)
+		return perrors.Wrap(err, "failed to connect to ZooKeeper")
 	}
+	defer c.Close() // ensure resource cleanup
 
 	valueBytes := []byte(configCenterZKClientConfig)
 	path := "/dubbo/config/dubbogo/dubbo-go-samples-configcenter-zookeeper-client"
+
+	// ensure path starts with '/'
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	paths := strings.Split(path, "/")
-	for idx := 2; idx < len(paths); idx++ {
-		tmpPath := strings.Join(paths[:idx], "/")
-		_, err = c.Create(tmpPath, []byte{}, 0, zk.WorldACL(zk.PermAll))
-		if err != nil && err != zk.ErrNodeExists {
-			panic(err)
-		}
+
+	// create parent paths
+	if err := createParentPaths(c, path); err != nil {
+		return perrors.Wrap(err, "failed to create parent paths")
 	}
 
+	// create or update config node
 	_, err = c.Create(path, valueBytes, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		if perrors.Is(err, zk.ErrNodeExists) {
-			_, stat, _ := c.Get(path)
+			// node exists, update its content
+			_, stat, getErr := c.Get(path)
+			if getErr != nil {
+				return perrors.Wrap(getErr, "failed to get existing node")
+			}
 			_, setErr := c.Set(path, valueBytes, stat.Version)
 			if setErr != nil {
-				panic(err)
+				return perrors.Wrap(setErr, "failed to update existing node")
 			}
+			logger.Info("Updated existing config node")
 		} else {
-			panic(err)
+			return perrors.Wrap(err, "failed to create config node")
+		}
+	} else {
+		logger.Info("Created new config node")
+	}
+
+	return nil
+}
+
+// helper function to create parent paths
+func createParentPaths(c *zk.Conn, path string) error {
+	paths := strings.Split(path, "/")
+	for idx := 2; idx < len(paths); idx++ {
+		tmpPath := strings.Join(paths[:idx], "/")
+		_, err := c.Create(tmpPath, []byte{}, 0, zk.WorldACL(zk.PermAll))
+		if err != nil && !perrors.Is(err, zk.ErrNodeExists) {
+			return perrors.Wrapf(err, "failed to create path: %s", tmpPath)
 		}
 	}
-	return err
+	return nil
 }
 
 const configCenterZKClientConfig = `## set in config center, group is 'dubbogo', dataid is 'dubbo-go-samples-configcenter-zookeeper-client', namespace is default

--- a/config_center/zookeeper/go-server/cmd/main.go
+++ b/config_center/zookeeper/go-server/cmd/main.go
@@ -50,13 +50,13 @@ func (srv *GreetTripleServer) Greet(ctx context.Context, req *greet.GreetRequest
 }
 
 func main() {
-	// 写入配置到配置中心
+	// Write configuration to the config center
 	if err := writeRuleToConfigCenter(); err != nil {
 		logger.Errorf("Failed to write config to config center: %v", err)
 		panic(err)
 	}
 
-	// 等待配置生效
+	// Wait for the configuration to take effect
 	time.Sleep(time.Second * 10)
 
 	ins, err := dubbo.NewInstance(
@@ -106,34 +106,34 @@ dubbo:
         interface: com.apache.dubbo.sample.basic.IGreeter
 `
 
-// ensurePath 确保路径存在（已移除，因为未使用）
+// ensurePath Ensure the path exists (removed because it is unused)
 
 func writeRuleToConfigCenter() error {
-	// 连接到 Zookeeper
+	// Connect to Zookeeper
 	c, _, err := zk.Connect([]string{"127.0.0.1:2181"}, time.Second*10)
 	if err != nil {
 		return perrors.Wrap(err, "failed to connect to zookeeper")
 	}
-	defer c.Close() // 确保连接被关闭
+	defer c.Close() // Ensure the connection is closed
 
 	valueBytes := []byte(configCenterZKServerConfig)
 	path := "/dubbo/config/dubbogo/dubbo-go-samples-configcenter-zookeeper-server"
 
-	// 确保路径以 / 开头
+	// Ensure the path starts with '/'
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
 
-	// 创建父路径
+	// Create parent paths
 	if err := createParentPaths(c, path); err != nil {
 		return perrors.Wrap(err, "failed to create parent paths")
 	}
 
-	// 创建或更新配置节点
+	// Create or update configuration node
 	_, err = c.Create(path, valueBytes, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		if perrors.Is(err, zk.ErrNodeExists) {
-			// 节点已存在，更新配置
+			// Node already exists, update configuration
 			_, stat, getErr := c.Get(path)
 			if getErr != nil {
 				return perrors.Wrap(getErr, "failed to get existing node")
@@ -153,7 +153,7 @@ func writeRuleToConfigCenter() error {
 	return nil
 }
 
-// createParentPaths 创建父路径
+// createParentPaths Create parent paths
 func createParentPaths(c *zk.Conn, path string) error {
 	paths := strings.Split(path, "/")
 	for idx := 2; idx < len(paths); idx++ {


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness and observability of ZooKeeper-based config center integration by adding error handling, logging, helper refactoring, and configuration cleanups.

Bug Fixes:
- Prevent panics during ZooKeeper operations by wrapping and returning errors instead of unhandled panics.

Enhancements:
- Add comprehensive error handling and structured logging for config center interactions in both go-client and go-server.
- Extract parent path creation into a createParentPaths helper and defer ZooKeeper connection closures for proper resource cleanup.
- Introduce context timeouts for remote calls, reduce fixed sleep durations, and log successful config writes and updates.
- Remove unused ensurePath function and clean up Nacos config template constants.